### PR TITLE
Dynamic root key

### DIFF
--- a/spec/serializer/base_spec.cr
+++ b/spec/serializer/base_spec.cr
@@ -65,11 +65,11 @@ describe Serializer::Base do
 
     context "with options" do
       it { single_serializer.serialize(opts: {:test => true}).should_not contain(%("Title")) }
-      it { single_serializer.serialize(opts: {:key_transform => :upcase}).should contain(%("TITLE")) }
+      it { single_serializer.serialize(opts: {:key_transform => "upcase"}).should contain(%("TITLE")) }
 
       context "with root key" do
-        it { single_serializer.serialize(opts: {:key_transform => :upcase}).should contain(%("DATA")) }
-        it { single_serializer.serialize(opts: {:key_transform => :upcase}, meta: { :count => 0}).should contain(%("META")) }
+        it { single_serializer.serialize(opts: {:key_transform => "upcase"}).should contain(%("DATA")) }
+        it { single_serializer.serialize(opts: {:key_transform => "upcase"}, meta: { :count => 0}).should contain(%("META")) }
       end
     end
 
@@ -87,7 +87,7 @@ describe Serializer::Base do
 
       context "with opts" do
         it do
-          single_serializer.serialize(meta: {:page => 0}, opts: { :key_transform => :upcase }).should contain(%("PAGE"))
+          single_serializer.serialize(meta: {:page => 0}, opts: { :key_transform => "upcase" }).should contain(%("PAGE"))
         end
       end
     end

--- a/spec/serializer/base_spec.cr
+++ b/spec/serializer/base_spec.cr
@@ -16,7 +16,7 @@ end
 
 class ModelWithRootSerializer < ModelSerializer
   def self.root_key
-    "model_with_root" 
+    "model_with_root"
   end
 end
 

--- a/spec/serializer/base_spec.cr
+++ b/spec/serializer/base_spec.cr
@@ -14,6 +14,12 @@ class ModelWithoutRootSerializer < ModelSerializer
   end
 end
 
+class ModelWithRootSerializer < ModelSerializer
+  def self.root_key
+    "model_with_root" 
+  end
+end
+
 describe Serializer::Base do
   single_serializer = ModelSerializer.new(Model.new)
 
@@ -95,6 +101,16 @@ describe Serializer::Base do
     context "without root" do
       it do
         ModelWithoutRootSerializer.new(Model.new).serialize.should eq("{\"name\":\"test\",\"Title\":\"asd\",\"own_field\":12}")
+      end
+
+    end
+
+    context "dynamic root" do
+      context "without default root" do
+        ModelWithoutRootSerializer.new(Model.new).serialize(opts: { :root_key => "model" }).should eq("{\"model\":{\"name\":\"test\",\"Title\":\"asd\",\"own_field\":12}}")
+      end
+      context "with default root" do
+        ModelWithRootSerializer.new(Model.new).serialize(opts: { :root_key => "model" }).should eq("{\"model\":{\"name\":\"test\",\"Title\":\"asd\",\"own_field\":12}}")
       end
     end
   end

--- a/spec/serializer/base_spec.cr
+++ b/spec/serializer/base_spec.cr
@@ -65,6 +65,7 @@ describe Serializer::Base do
 
     context "with options" do
       it { single_serializer.serialize(opts: {:test => true}).should_not contain(%("Title")) }
+      it { single_serializer.serialize(opts: {:case => :upcase}).should contain(%("TITLE")) }
     end
 
     context "with meta" do

--- a/spec/serializer/base_spec.cr
+++ b/spec/serializer/base_spec.cr
@@ -65,7 +65,7 @@ describe Serializer::Base do
 
     context "with options" do
       it { single_serializer.serialize(opts: {:test => true}).should_not contain(%("Title")) }
-      it { single_serializer.serialize(opts: {:case => :upcase}).should contain(%("TITLE")) }
+      it { single_serializer.serialize(opts: {:key_transform => :upcase}).should contain(%("TITLE")) }
     end
 
     context "with meta" do

--- a/spec/serializer/base_spec.cr
+++ b/spec/serializer/base_spec.cr
@@ -66,6 +66,11 @@ describe Serializer::Base do
     context "with options" do
       it { single_serializer.serialize(opts: {:test => true}).should_not contain(%("Title")) }
       it { single_serializer.serialize(opts: {:key_transform => :upcase}).should contain(%("TITLE")) }
+
+      context "with root key" do
+        it { single_serializer.serialize(opts: {:key_transform => :upcase}).should contain(%("DATA")) }
+        it { single_serializer.serialize(opts: {:key_transform => :upcase}, meta: { :count => 0}).should contain(%("META")) }
+      end
     end
 
     context "with meta" do
@@ -78,6 +83,12 @@ describe Serializer::Base do
         it { AddressWithMetaSerializer.new(Address.new).serialize.should eq("{\"data\":{\"street\":\"some street\"},\"meta\":{\"page\":0}}") }
         it { AddressWithMetaSerializer.new(Address.new).serialize(meta: {:total => 0}).should eq("{\"data\":{\"street\":\"some street\"},\"meta\":{\"page\":0,\"total\":0}}") }
         it { AddressWithMetaSerializer.new(Address.new).serialize(meta: {:page => 3}).should eq("{\"data\":{\"street\":\"some street\"},\"meta\":{\"page\":3}}") }
+      end
+
+      context "with opts" do
+        it do
+          single_serializer.serialize(meta: {:page => 0}, opts: { :key_transform => :upcase }).should contain(%("PAGE"))
+        end
       end
     end
 

--- a/src/serializer/base.cr
+++ b/src/serializer/base.cr
@@ -164,6 +164,7 @@ module Serializer
     # :nodoc:
     def key_transform(string, opts)
       return string if string.nil?
+      string = string.as(String)
       # not the best code
       if opts && opts.has_key?(:key_transform)
         case opts[:key_transform]
@@ -205,7 +206,8 @@ module Serializer
 
     # :nodoc:
     def render_root(io : IO, except : Array, includes : Array | Hash, opts : Hash?, meta)
-      key = key_transform(self.class.root_key, opts)
+      root_key = (opts && opts.has_key?(:root_key)) ? opts[:root_key] : self.class.root_key
+      key = key_transform(root_key, opts)
       io << "{\"" << key << "\":"
       _serialize(@target, io, except, includes, opts)
       default_meta = self.class.meta(opts)

--- a/src/serializer/base.cr
+++ b/src/serializer/base.cr
@@ -164,10 +164,12 @@ module Serializer
     # :nodoc:
     def key_transform(string, opts)
       # not the best code
-      if opts && opts.has_key?(:case)
+      if opts && opts.has_key?(:key_transform)
         case opts[:case]
-        when :camelcase
+        when :camelcase_down
           string.camelcase(lower: true)
+        when :camelcase_up
+          string.camelcase
         when :upcase
           string.upcase
         when :downcase

--- a/src/serializer/base.cr
+++ b/src/serializer/base.cr
@@ -109,7 +109,8 @@ module Serializer
                 if !except.includes?(:{{name.id}}) {% if props[:if] %} && {{props[:if].id}}(object, opts) {% end %}
                   io << "," if fields_count > 0
                   fields_count += 1
-                  io << "\"{{props[:key].id}}\":" << {{target.id}}.{{name.id}}.to_json
+                  key = key_transform("{{props[:key].id}}", opts)
+                  io << "\"#{key}\":" << {{target.id}}.{{name.id}}.to_json
                 end
               {% end %}
               fields_count
@@ -125,7 +126,8 @@ module Serializer
                 if has_relation?({{name}}, includes)
                   io << "," if fields_count > 0
                   fields_count += 1
-                  io << "\"{{props[:key].id}}\":"
+                  key = key_transform("{{props[:key].id}}", opts)
+                  io << "\"#{key}\":"
                   {{props[:serializer]}}.new(object.{{name.id}})._serialize(object.{{name.id}}, io, [] of Symbol, nested_includes({{name}}, includes), opts)
                 end
                 {% end %}
@@ -157,6 +159,27 @@ module Serializer
 
     def serialize_relations(object, fields_count, io, includes, opts)
       fields_count
+    end
+
+    # :nodoc:
+    def key_transform(string, opts)
+      # not the best code
+      if opts && opts.has_key?(:case)
+        case opts[:case]
+        when :camelcase
+          string.camelcase(lower: true)
+        when :upcase
+          string.upcase
+        when :downcase
+          string.downcase
+        when :underscore
+          string.underscore
+        else
+          string
+        end
+      else
+        string
+      end
     end
 
     # :nodoc:

--- a/src/serializer/base.cr
+++ b/src/serializer/base.cr
@@ -209,12 +209,17 @@ module Serializer
       io << "{\"" << key << "\":"
       _serialize(@target, io, except, includes, opts)
       default_meta = self.class.meta(opts)
+      metas = {} of String => MetaAny
+      default_meta.each do |k,v|
+        metas[key_transform(k.to_s, opts)] = v
+      end
       unless meta.nil?
         meta.each do |key, value|
-          default_meta[key] = value
+          metas[key_transform(key.to_s, opts)] = value
         end
       end
-      io << %(,"meta":) << default_meta.to_json unless default_meta.empty?
+
+      io << ",\"#{ key_transform("meta", opts)}\":" << metas.to_json unless metas.empty?
       io << "}"
     end
   end

--- a/src/serializer/base.cr
+++ b/src/serializer/base.cr
@@ -163,9 +163,10 @@ module Serializer
 
     # :nodoc:
     def key_transform(string, opts)
+      return string if string.nil?
       # not the best code
       if opts && opts.has_key?(:key_transform)
-        case opts[:case]
+        case opts[:key_transform]
         when :camelcase_down
           string.camelcase(lower: true)
         when :camelcase_up
@@ -204,7 +205,8 @@ module Serializer
 
     # :nodoc:
     def render_root(io : IO, except : Array, includes : Array | Hash, opts : Hash?, meta)
-      io << "{\"" << self.class.root_key << "\":"
+      key = key_transform(self.class.root_key, opts)
+      io << "{\"" << key << "\":"
       _serialize(@target, io, except, includes, opts)
       default_meta = self.class.meta(opts)
       unless meta.nil?

--- a/src/serializer/base.cr
+++ b/src/serializer/base.cr
@@ -167,15 +167,15 @@ module Serializer
       # not the best code
       if opts && opts.has_key?(:key_transform)
         case opts[:key_transform]
-        when :camelcase_down
+        when "camelcase_down"
           string.camelcase(lower: true)
-        when :camelcase_up
+        when "camelcase_up"
           string.camelcase
-        when :upcase
+        when "upcase"
           string.upcase
-        when :downcase
+        when "downcase"
           string.downcase
-        when :underscore
+        when "underscore"
           string.underscore
         else
           string

--- a/src/serializer/serializable.cr
+++ b/src/serializer/serializable.cr
@@ -69,10 +69,11 @@ module Serializer
     #     :children => {:address => nil, :dipper => [:address]},
     #   },
     #   meta: {:page => 0},
-    #   opts: { :key_transform => :camelcase_up }
+    #   opts: { :key_transform => "camelcase_up", :root_key => "people" }
     # )
     # ```
-    # *key_transform* can either be :upcase, :downcase, :underscore, :camelcase_down or :camelcase_up
+    # *key_transform* can either be "upcase", "downcase", "underscore", "camelcase_down" or "camelcase_up"
+    # *root_key* dynamically sets the root key, overriding the default one
     # ## Includes
     #
     # *includes* option accepts `Array` or `Hash` values. To define just a list of association of target object - just pass an array:
@@ -92,7 +93,7 @@ module Serializer
 
     # :nodoc:
     def serialize(io : IO, except = %i(), includes = %i(), opts : Hash? = nil, meta : Hash? = nil)
-      if self.class.root_key.nil?
+      if self.class.root_key.nil? && !(opts && opts.has_key?(:root_key))
         _serialize(@target, io, except, includes, opts)
       else
         render_root(io, except, includes, opts, meta)

--- a/src/serializer/serializable.cr
+++ b/src/serializer/serializable.cr
@@ -58,7 +58,7 @@ module Serializer
     #
     # * *except* - array of fields should be excluded from serialization;
     # * *includes* - definition of relation that should be included into serialized string;
-    # * *opts* - options that will be passed to methods defined for *if* attribute options and `.meta`;
+    # * *opts* - options that will be passed to methods defined for *if* attribute options, key transform and `.meta`;
     # * *meta* - meta attributes to be added under `"meta"` key at root level; it is merge into default
     # meta attributes returned by `.meta`.
     #
@@ -68,10 +68,11 @@ module Serializer
     #   includes: {
     #     :children => {:address => nil, :dipper => [:address]},
     #   },
-    #   meta: {:page => 0}
+    #   meta: {:page => 0},
+    #   opts: { :key_transform => :camelcase_up }
     # )
     # ```
-    #
+    # *key_transform* can either be :upcase, :downcase, :underscore, :camelcase_down or :camelcase_up
     # ## Includes
     #
     # *includes* option accepts `Array` or `Hash` values. To define just a list of association of target object - just pass an array:


### PR DESCRIPTION
Add a way to set root key during serialize call. Useful for those times when you need to translate or pluralize the root key.